### PR TITLE
fix: 🐛 safari toggle button disabled bug

### DIFF
--- a/src/KeyboardController/KeyboardController.test.tsx
+++ b/src/KeyboardController/KeyboardController.test.tsx
@@ -38,6 +38,7 @@ function renderKeyboardController() {
     rightHandActiveKeys,
     selectChord,
     selectKey,
+    keyboard,
   };
 }
 

--- a/src/KeyboardController/KeyboardController.tsx
+++ b/src/KeyboardController/KeyboardController.tsx
@@ -119,11 +119,12 @@ export const KeyboardController = () => {
         aria-label="Toggle button keys"
       >
         {keys.map((note) => {
+          const key = note + String(selectedChord ? selectedChord?.name : "");
           return (
             <CustomToggleButton
               role="button"
               aria-label={note}
-              key={note}
+              key={key}
               value={note}
               disabled={!selectedChord}
             >


### PR DESCRIPTION
providing a unique react key solved this